### PR TITLE
Fix some unit tests for ruby 3+

### DIFF
--- a/spec/orchestration_executor_spec.rb
+++ b/spec/orchestration_executor_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Simplekiq::OrchestrationExecutor do
       let(:workflow) { [] }
 
       it "immediately calls the orchestration callbacks" do
-        expect(job).to receive(:on_success).with(nil, "args" => ["some", "args"])
+        expect(job).to receive(:on_success).with(nil, { "args" => ["some", "args"] })
 
         execute
       end

--- a/spec/simplekiq_spec.rb
+++ b/spec/simplekiq_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe Simplekiq do
     end
 
     it "calls the on_success and on_complete callback methods on the job" do
-      expect(job).to receive(:on_complete).with(nil, "args" => [1, 2, 3])
-      expect(job).to receive(:on_success).with(nil, "args" => [1, 2, 3])
+      expect(job).to receive(:on_complete).with(nil, { "args" => [1, 2, 3] })
+      expect(job).to receive(:on_success).with(nil, { "args" => [1, 2, 3] })
       call
     end
 


### PR DESCRIPTION
Due to https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/ we need to explicitly wrap these as a hash arg, they are not kwargs.