### PR TITLE
Add more context to batch descriptions

### DIFF
--- a/lib/simplekiq.rb
+++ b/lib/simplekiq.rb
@@ -17,12 +17,5 @@ module Simplekiq
 
       job.define_custom_batch_callbacks(batch) if job.respond_to?(:define_custom_batch_callbacks)
     end
-
-    def format_args(args)
-      return args unless args.is_a?(Array)
-      return args unless args[0].is_a?(Hash)
-
-      args[0].map { |key, value| "#{key}=#{value}" }.join(" ")
-    end
   end
 end

--- a/lib/simplekiq.rb
+++ b/lib/simplekiq.rb
@@ -17,5 +17,12 @@ module Simplekiq
 
       job.define_custom_batch_callbacks(batch) if job.respond_to?(:define_custom_batch_callbacks)
     end
+
+    def format_args(args)
+      return args unless args.is_a?(Array)
+      return args unless args[0].is_a?(Hash)
+
+      args[0].map { |key, value| "#{key}=#{value}" }.join(" ")
+    end
   end
 end

--- a/lib/simplekiq/orchestration_executor.rb
+++ b/lib/simplekiq/orchestration_executor.rb
@@ -12,7 +12,7 @@ module Simplekiq
       end
     end
 
-    def run_step(workflow, step, orchestration_job_class_name, orchestration_batch_bid)
+    def run_step(workflow, step, orchestration_job_class_name)
       *jobs = workflow.at(step)
       # This will never be empty because Orchestration#serialized_workflow skips inserting
       # a new step for in_parallel if there were no inner jobs specified.

--- a/lib/simplekiq/orchestration_executor.rb
+++ b/lib/simplekiq/orchestration_executor.rb
@@ -4,7 +4,7 @@ module Simplekiq
   class OrchestrationExecutor
     def self.execute(args:, job:, workflow:)
       orchestration_batch = Sidekiq::Batch.new
-      orchestration_batch.description = "[Simplekiq] #{job.class.name}. Params: #{Simplekiq.format_args(args)}"
+      orchestration_batch.description = "[Simplekiq] #{job.class.name}. Params: #{args}}"
       Simplekiq.auto_define_callbacks(orchestration_batch, args: args, job: job)
 
       orchestration_batch.jobs do

--- a/lib/simplekiq/orchestration_executor.rb
+++ b/lib/simplekiq/orchestration_executor.rb
@@ -19,7 +19,7 @@ module Simplekiq
 
       next_step = step + 1
       step_batch = Sidekiq::Batch.new
-      step_batch.description = "[Simplekiq] step #{next_step} in #{orchestration_job_class_name}."
+      step_batch.description = step_batch_description(jobs)
       step_batch.on(
         "success",
         self.class,
@@ -43,6 +43,19 @@ module Simplekiq
       Sidekiq::Batch.new(status.parent_bid).jobs do
         run_step(options["orchestration_workflow"], options["step"], options["orchestration_job_class_name"])
       end
+    end
+
+    private
+
+    def step_batch_description(jobs)
+      description = "[Simplekiq] step #{step} in #{orchestration_job_class_name}. "
+      if jobs.length > 1
+        description += "Running #{jobs.length} jobs in parallel."
+      else
+        description += "Running #{jobs[0]["klass"]}."
+      end
+
+      description
     end
   end
 end

--- a/lib/simplekiq/orchestration_executor.rb
+++ b/lib/simplekiq/orchestration_executor.rb
@@ -8,7 +8,7 @@ module Simplekiq
       Simplekiq.auto_define_callbacks(orchestration_batch, args: args, job: job)
 
       orchestration_batch.jobs do
-        new.run_step(workflow, 0, job.class.name, orchestration_batch.bid) unless workflow.empty?
+        new.run_step(workflow, 0, job.class.name) unless workflow.empty?
       end
     end
 
@@ -19,8 +19,7 @@ module Simplekiq
 
       next_step = step + 1
       step_batch = Sidekiq::Batch.new
-      step_batch.description = "[Simplekiq] step #{next_step} in #{orchestration_job_class_name}. " \
-        "Orchestration batch ID: #{orchestration_batch_bid}."
+      step_batch.description = "[Simplekiq] step #{next_step} in #{orchestration_job_class_name}."
       step_batch.on(
         "success",
         self.class,
@@ -28,7 +27,6 @@ module Simplekiq
           "orchestration_workflow" => workflow,
           "step" => next_step,
           "orchestration_job_class_name" => orchestration_job_class_name,
-          "orchestration_batch_bid" => orchestration_batch_bid,
         }
       )
 
@@ -43,7 +41,7 @@ module Simplekiq
       return if options["step"] == options["orchestration_workflow"].length
 
       Sidekiq::Batch.new(status.parent_bid).jobs do
-        run_step(options["orchestration_workflow"], options["step"], options["orchestration_job_class_name"], options["orchestration_batch_bid"])
+        run_step(options["orchestration_workflow"], options["step"], options["orchestration_job_class_name"])
       end
     end
   end

--- a/lib/simplekiq/orchestration_executor.rb
+++ b/lib/simplekiq/orchestration_executor.rb
@@ -4,7 +4,7 @@ module Simplekiq
   class OrchestrationExecutor
     def self.execute(args:, job:, workflow:)
       orchestration_batch = Sidekiq::Batch.new
-      orchestration_batch.description = "[Simplekiq] #{job.class.name}. Params: #{args}}"
+      orchestration_batch.description = "[Simplekiq] #{job.class.name}. Params: #{args}"
       Simplekiq.auto_define_callbacks(orchestration_batch, args: args, job: job)
 
       orchestration_batch.jobs do

--- a/lib/simplekiq/orchestration_executor.rb
+++ b/lib/simplekiq/orchestration_executor.rb
@@ -19,7 +19,7 @@ module Simplekiq
 
       next_step = step + 1
       step_batch = Sidekiq::Batch.new
-      step_batch.description = step_batch_description(jobs, step, orchestration_job_class_name)
+      step_batch.description = step_batch_description(jobs, next_step, orchestration_job_class_name)
       step_batch.on(
         "success",
         self.class,

--- a/lib/simplekiq/orchestration_executor.rb
+++ b/lib/simplekiq/orchestration_executor.rb
@@ -19,7 +19,7 @@ module Simplekiq
 
       next_step = step + 1
       step_batch = Sidekiq::Batch.new
-      step_batch.description = step_batch_description(jobs)
+      step_batch.description = step_batch_description(jobs, step, orchestration_job_class_name)
       step_batch.on(
         "success",
         self.class,
@@ -47,7 +47,7 @@ module Simplekiq
 
     private
 
-    def step_batch_description(jobs)
+    def step_batch_description(jobs, step, orchestration_job_class_name)
       description = "[Simplekiq] step #{step} in #{orchestration_job_class_name}. "
       if jobs.length > 1
         description += "Running #{jobs.length} jobs in parallel."

--- a/spec/orchestration_executor_spec.rb
+++ b/spec/orchestration_executor_spec.rb
@@ -20,14 +20,14 @@ RSpec.describe Simplekiq::OrchestrationExecutor do
 
   describe ".execute" do
     def execute
-      described_class.execute(args: ["some", "args"], job: job, workflow: workflow)
+      described_class.execute(args: [{ "some" => "args" }], job: job, workflow: workflow)
     end
 
     it "kicks off the first step with a new batch" do
       batch_double = instance_double(Sidekiq::Batch, bid: 42)
       allow(Sidekiq::Batch).to receive(:new).and_return(batch_double)
-      expect(batch_double).to receive(:description=).with("FakeOrchestration Simplekiq orchestration")
-      expect(batch_double).to receive(:on).with("success", FakeOrchestration, "args" => ["some", "args"])
+      expect(batch_double).to receive(:description=).with("[Simplekiq] FakeOrchestration. Params: some=args")
+      expect(batch_double).to receive(:on).with("success", FakeOrchestration, "args" =>  [{ "some" => "args" }])
 
       batch_stack_depth = 0 # to keep track of how deeply nested within batches we are
       expect(batch_double).to receive(:jobs) do |&block|
@@ -48,7 +48,7 @@ RSpec.describe Simplekiq::OrchestrationExecutor do
   end
 
   describe "run_step" do
-    let(:step_batch) { instance_double(Sidekiq::Batch) }
+    let(:step_batch) { instance_double(Sidekiq::Batch, bid: 42) }
     let(:step) { 0 }
     let(:instance) { described_class.new }
 
@@ -68,11 +68,13 @@ RSpec.describe Simplekiq::OrchestrationExecutor do
       allow(Sidekiq::Batch).to receive(:new).and_return(step_batch)
       expect(step_batch).to receive(:on).with("success", described_class, {
         "orchestration_workflow" => workflow,
-        "step" => 1
+        "step" => 1,
+        "orchestration_job_class_name" => "FakeOrchestration",
+        "orchestration_batch_bid" => 42
       })
-      expect(step_batch).to receive(:description=).with("Simplekiq orchestrated step 1")
+      expect(step_batch).to receive(:description=).with("[Simplekiq] step 1 in FakeOrchestration. Orchestration batch ID: 42.")
 
-      instance.run_step(workflow, 0)
+      instance.run_step(workflow, 0, "FakeOrchestration", 42)
     end
   end
 end

--- a/spec/orchestration_executor_spec.rb
+++ b/spec/orchestration_executor_spec.rb
@@ -70,11 +70,10 @@ RSpec.describe Simplekiq::OrchestrationExecutor do
         "orchestration_workflow" => workflow,
         "step" => 1,
         "orchestration_job_class_name" => "FakeOrchestration",
-        "orchestration_batch_bid" => 42
       })
-      expect(step_batch).to receive(:description=).with("[Simplekiq] step 1 in FakeOrchestration. Orchestration batch ID: 42.")
+      expect(step_batch).to receive(:description=).with("[Simplekiq] step 1 in FakeOrchestration.")
 
-      instance.run_step(workflow, 0, "FakeOrchestration", 42)
+      instance.run_step(workflow, 0, "FakeOrchestration")
     end
   end
 end

--- a/spec/orchestration_executor_spec.rb
+++ b/spec/orchestration_executor_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Simplekiq::OrchestrationExecutor do
     it "kicks off the first step with a new batch" do
       batch_double = instance_double(Sidekiq::Batch, bid: 42)
       allow(Sidekiq::Batch).to receive(:new).and_return(batch_double)
-      expect(batch_double).to receive(:description=).with("[Simplekiq] FakeOrchestration. Params: some=args")
+      expect(batch_double).to receive(:description=).with("[Simplekiq] FakeOrchestration. Params: [{\"some\"=>\"args\"}]")
       expect(batch_double).to receive(:on).with("success", FakeOrchestration, "args" =>  [{ "some" => "args" }])
 
       batch_stack_depth = 0 # to keep track of how deeply nested within batches we are

--- a/spec/orchestration_executor_spec.rb
+++ b/spec/orchestration_executor_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Simplekiq::OrchestrationExecutor do
         "step" => 1,
         "orchestration_job_class_name" => "FakeOrchestration",
       })
-      expect(step_batch).to receive(:description=).with("[Simplekiq] step 1 in FakeOrchestration.")
+      expect(step_batch).to receive(:description=).with("[Simplekiq] step 1 in FakeOrchestration. Running OrcTest::JobA.")
 
       instance.run_step(workflow, 0, "FakeOrchestration")
     end


### PR DESCRIPTION
Before

![image](https://github.com/user-attachments/assets/edd88aa6-90de-41c9-b236-8c4584560947)


Now

![image](https://github.com/user-attachments/assets/4f377dec-4735-4479-a4e5-a4dd869a2ecf)


Changes:
- add [simplekiq] prefix to hopefully make it clear these batches are from simplekiq
- add the worker name and params to the description
- add the orchestration batch ID to the batch description of "step batches" so engineers can use it to figure out what the original params to the orchestration job were