### PR TITLE
Use serialized opts for calling set before enqueueing

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,13 +109,13 @@ end
 
 Inside `OrchestrationJob`, it's possible to set options that will be used for all the child jobs inside the workflow. Viable options are anything that would be called to the Sidekiq's `#set` call from the `Setter` API.
 
-Redefine the `child_job_options` class method on your OrchestrationJob to provide the options to the child jobs. Note that this method is only called at the start of orchestration, so you only have access to the initial `args` passed to the `OrchestratorJob` available to use. `child_job_options` must return a hash.
+Redefine the `child_job_options` method on your OrchestrationJob to provide the options to the child jobs. Note that this method is only called at the start of orchestration, so you only have access to the initial `args` passed to the `OrchestratorJob` available to use. `child_job_options` must return a hash.
 
 ```ruby
 class SomeOrchestrationJob
   include Simplekiq::OrchestrationJob
 
-  def self.child_job_options(*args)
+  def child_job_options(*args)
     if args[0] = "good"
       { "queue" => "the-good-queue" }
     else

--- a/README.md
+++ b/README.md
@@ -105,6 +105,29 @@ else # there's no parent batches, this job was run directly outside of an orches
 end
 ```
 
+#### Setting Orchestration-Wide Options
+
+Inside `OrchestrationJob`, it's possible to set options that will be used for all the child jobs inside the workflow. Viable options are anything that would be called to the Sidekiq's `#set` call from the `Setter` API.
+
+Redefine the `child_job_options` class method on your OrchestrationJob to provide the options to the child jobs. Note that this method is only called at the start of orchestration, so you only have access to the initial `args` passed to the `OrchestratorJob` available to use. `child_job_options` must return a hash.
+
+```ruby
+class SomeOrchestrationJob
+  include Simplekiq::OrchestrationJob
+
+  def self.child_job_options(*args)
+    if args[0] = "good"
+      { "queue" => "the-good-queue" }
+    else
+      { "queue" => "the-bad-queue", "retry_queue" => "the-worse-queue" }
+    end
+  end
+
+  def perform_orchestration(some_id)
+    # ...as usual
+  end
+```
+
 ### Simplekiq::BatchingJob
 
 See the [Simplekiq::BatchingJob](./lib/simplekiq/batching_job.rb) module itself for a description and example usage in the header comments. Nutshell is that you should use this if you're planning on making a batched asynchronous process as it shaves off a lot of ceremony and unexpressive structure. eg - Instead of having `BeerBottlerJob` which queues some number of `BeerBottlerBatchJob`s to handle the broken down sub-tasks you can just have `BeerBottlerJob` with a method for batching, executing individual batches, and a callback that gets run after all batches have completed successfully.

--- a/lib/simplekiq/orchestration.rb
+++ b/lib/simplekiq/orchestration.rb
@@ -3,9 +3,9 @@
 module Simplekiq
   class Orchestration
     attr_accessor :serial_workflow, :parallel_workflow
-    def initialize(job_options: {})
+    def initialize(child_job_options: {})
       @serial_workflow = []
-      @job_options = job_options
+      @child_job_options = child_job_options
     end
 
     def run(*step)
@@ -27,11 +27,11 @@ module Simplekiq
         case step[0]
         when Array
           step.map do |(job, *args)|
-            {"klass" => job.name, "opts" => @job_options, "args" => args}
+            {"klass" => job.name, "opts" => @child_job_options, "args" => args}
           end
         when Class
           job, *args = step
-          {"klass" => job.name, "opts" => @job_options, "args" => args}
+          {"klass" => job.name, "opts" => @child_job_options, "args" => args}
         end
       end
     end

--- a/lib/simplekiq/orchestration.rb
+++ b/lib/simplekiq/orchestration.rb
@@ -3,6 +3,7 @@
 module Simplekiq
   class Orchestration
     attr_accessor :serial_workflow, :parallel_workflow
+
     def initialize(child_job_options: {})
       @serial_workflow = []
       @child_job_options = child_job_options

--- a/lib/simplekiq/orchestration.rb
+++ b/lib/simplekiq/orchestration.rb
@@ -3,14 +3,9 @@
 module Simplekiq
   class Orchestration
     attr_accessor :serial_workflow, :parallel_workflow
-    def initialize
+    def initialize(job_options: {})
       @serial_workflow = []
-      @job_options = {}
-    end
-
-    def with_job_options(**options)
-      @job_options = options
-      self
+      @job_options = job_options
     end
 
     def run(*step)

--- a/lib/simplekiq/orchestration.rb
+++ b/lib/simplekiq/orchestration.rb
@@ -5,6 +5,12 @@ module Simplekiq
     attr_accessor :serial_workflow, :parallel_workflow
     def initialize
       @serial_workflow = []
+      @job_options = {}
+    end
+
+    def with_job_options(**options)
+      @job_options = options
+      self
     end
 
     def run(*step)
@@ -26,11 +32,11 @@ module Simplekiq
         case step[0]
         when Array
           step.map do |(job, *args)|
-            {"klass" => job.name, "args" => args}
+            {"klass" => job.name, "opts" => @job_options, "args" => args}
           end
         when Class
           job, *args = step
-          {"klass" => job.name, "args" => args}
+          {"klass" => job.name, "opts" => @job_options, "args" => args}
         end
       end
     end

--- a/lib/simplekiq/orchestration_executor.rb
+++ b/lib/simplekiq/orchestration_executor.rb
@@ -32,7 +32,7 @@ module Simplekiq
 
       step_batch.jobs do
         jobs.each do |job|
-          Object.const_get(job["klass"]).perform_async(*job["args"])
+          Object.const_get(job["klass"]).set(job["opts"]).perform_async(*job["args"])
         end
       end
     end

--- a/lib/simplekiq/orchestration_job.rb
+++ b/lib/simplekiq/orchestration_job.rb
@@ -10,16 +10,6 @@ module Simplekiq
     def_delegators :orchestration, :run, :in_parallel
     attr_reader :orchestration
 
-    def self.included(klass)
-      klass.extend ClassMethods
-    end
-
-    module ClassMethods
-      def child_job_options(*args)
-       {}
-      end
-    end
-
     def perform(*args)
       build_orchestration(*args)
       perform_orchestration(*args)
@@ -52,8 +42,12 @@ module Simplekiq
 
     def build_orchestration(*args)
       @orchestration ||= Orchestration.new(
-        child_job_options: self.class.child_job_options(*args)
+        child_job_options: child_job_options(*args)
       )
+    end
+
+    def child_job_options(*args)
+      {}
     end
   end
 end

--- a/lib/simplekiq/orchestration_job.rb
+++ b/lib/simplekiq/orchestration_job.rb
@@ -39,7 +39,11 @@ module Simplekiq
     end
 
     def orchestration
-      @orchestration ||= Orchestration.new.with_job_options(**job_options)
+      @orchestration ||= Orchestration.new(job_options: job_options)
+    end
+
+    def job_options
+      {}
     end
   end
 end

--- a/lib/simplekiq/orchestration_job.rb
+++ b/lib/simplekiq/orchestration_job.rb
@@ -39,7 +39,7 @@ module Simplekiq
     end
 
     def orchestration
-      @orchestration ||= Orchestration.new
+      @orchestration ||= Orchestration.new.with_job_options(**job_options)
     end
   end
 end

--- a/lib/simplekiq/orchestration_job.rb
+++ b/lib/simplekiq/orchestration_job.rb
@@ -39,10 +39,10 @@ module Simplekiq
     end
 
     def orchestration
-      @orchestration ||= Orchestration.new(job_options: job_options)
+      @orchestration ||= Orchestration.new(child_job_options: child_job_options)
     end
 
-    def job_options
+    def child_job_options
       {}
     end
   end

--- a/spec/orchestration_executor_spec.rb
+++ b/spec/orchestration_executor_spec.rb
@@ -16,7 +16,13 @@ RSpec.describe Simplekiq::OrchestrationExecutor do
     FakeOrchestration.new
   end
 
-  before { stub_const("OrcTest::JobA", Class.new) }
+  before { stub_const("OrcTest::JobA", Class.new do
+    class << self
+      def set(options)
+        self
+      end
+    end
+  end) }
 
   describe ".execute" do
     def execute

--- a/spec/orchestration_job_spec.rb
+++ b/spec/orchestration_job_spec.rb
@@ -93,11 +93,15 @@ RSpec.describe Simplekiq::OrchestrationJob do
       stub_const("FakeOrchestration", Class.new do
         include Simplekiq::OrchestrationJob
         def perform_orchestration(first, second)
-          run OrcTest::JobA, first
+          run OrcTest::JobA, first, second
         end
 
-        def child_job_options
-          { "queue" => "test-queue" }
+        def self.child_job_options(*args)
+          if args.first == "some"
+            { "queue" => "some-test-queue" }
+          else
+            { "queue" => "other-test-queue" }
+          end
         end
       end)
 
@@ -109,7 +113,7 @@ RSpec.describe Simplekiq::OrchestrationJob do
         args: ["some", "args"],
         job: job,
         workflow: [
-          {"klass" => "OrcTest::JobA", "args" => ["some"], "opts" => { "queue" => "test-queue" }},
+          {"klass" => "OrcTest::JobA", "args" => ["some", "args"], "opts" => { "queue" => "some-test-queue" }},
         ]
       )
 

--- a/spec/orchestration_job_spec.rb
+++ b/spec/orchestration_job_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe Simplekiq::OrchestrationJob do
         run OrcTest::JobA, first
         run OrcTest::JobB, second
       end
+
+      def job_options
+        {}
+      end
     end)
 
     FakeOrchestration.new
@@ -28,8 +32,8 @@ RSpec.describe Simplekiq::OrchestrationJob do
       args: ["some", "args"],
       job: job,
       workflow: [
-        {"klass" => "OrcTest::JobA", "args" => ["some"]},
-        {"klass" => "OrcTest::JobB", "args" => ["args"]}
+        {"klass" => "OrcTest::JobA", "args" => ["some"], "opts" => {}},
+        {"klass" => "OrcTest::JobB", "args" => ["args"], "opts" => {}}
       ]
     )
 
@@ -66,6 +70,10 @@ RSpec.describe Simplekiq::OrchestrationJob do
             run OrcTest::JobC, second
           end
         end
+
+        def job_options
+          {}
+        end
       end)
 
       FakeOrchestration.new
@@ -76,10 +84,10 @@ RSpec.describe Simplekiq::OrchestrationJob do
         args: ["some", "args"],
         job: job,
         workflow: [
-          {"klass" => "OrcTest::JobA", "args" => ["some"]},
+          {"klass" => "OrcTest::JobA", "args" => ["some"], "opts" => {}},
           [
-            {"klass" => "OrcTest::JobB", "args" => ["some"]},
-            {"klass" => "OrcTest::JobC", "args" => ["args"]}
+            {"klass" => "OrcTest::JobB", "args" => ["some"], "opts" => {}},
+            {"klass" => "OrcTest::JobC", "args" => ["args"], "opts" => {}}
           ]
         ]
       )

--- a/spec/orchestration_job_spec.rb
+++ b/spec/orchestration_job_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe Simplekiq::OrchestrationJob do
           run OrcTest::JobA, first, second
         end
 
-        def self.child_job_options(*args)
+        def child_job_options(*args)
           if args.first == "some"
             { "queue" => "some-test-queue" }
           else

--- a/spec/orchestration_job_spec.rb
+++ b/spec/orchestration_job_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe Simplekiq::OrchestrationJob do
           run OrcTest::JobA, first
         end
 
-        def job_options
+        def child_job_options
           { "queue" => "test-queue" }
         end
       end)

--- a/spec/orchestration_spec.rb
+++ b/spec/orchestration_spec.rb
@@ -34,8 +34,8 @@ RSpec.describe Simplekiq::Orchestration do
       it "adds a step" do
         expect(subject).to eq [
           [
-            {"klass" => "OrcTest::JobA", "args" => ["syn"]},
-            {"klass" => "OrcTest::JobB", "args" => ["ack"]}
+            {"klass" => "OrcTest::JobA", "args" => ["syn"], "opts" => {}},
+            {"klass" => "OrcTest::JobB", "args" => ["ack"], "opts" => {}}
           ]
         ]
       end


### PR DESCRIPTION
This PR is to allow setter-style arguments to elements of the the orchestrated workflow. Our current use case is overriding a queue for high-priority situations, but it should work with any of the valid options for `Sidekiq::Job#set`.

- sets an orchestration-wide `@job_options` on the Orchestrator object, which ...
- serializes into the new `"opts"`   key for the existing job hash in `Orchestration#run`, which...
- gets used in a setter in the `OrchestrationExecutor` class.